### PR TITLE
Added custom server-status URL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,16 @@ Run the script on the command line:
 You can also pass the script a number to limit the lines of results returned (good for viewing on small screens). The default is 300 lines.
 
 ````
-./atop 50
+./atop -n 50
 ````
 
 This would limit the results to 50 lines.
+
+You can specify a different server-status location like so:
+
+```
+./atop -u http://127.0.0.1:8080/server-status
+```
 
 See here for a blog post on using atop: <a href="http://mossiso.com/2014/04/02/atop-apache-top-for-keeping-tabs-on-the-web-servers.html">http://mossiso.com/2014/04/02/atop-apache-top-for-keeping-tabs-on-the-web-servers.html</a>
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ c = sort by CPU, no GCRK_
 i = list IPs connected to port 80 (uses Apache Server Status)
 k = sort by K (Keep alives)
 l = list IPs connected to all ports (uses netstat)
+m = list IPs connected to port 443 (uses netstat)
 n = list IPs connected to port 80 (uses netstat)
 o = sort open connections by CPU
 p = sort only POST threads by time
@@ -56,6 +57,13 @@ w = sort by inactive workers
 q = quit
 ````
 
+## Optional arguments
+```
+-h, --help            show this help message and exit
+-n, --number          Limit number of lines returned (default 300)
+-d, --delay           Delay between updates (seconds) (default 2)
+-u, --url             Specify apache status URL (default: http://127.0.0.1/server-status)
+```
 
 ## Similar Programs
 

--- a/atop
+++ b/atop
@@ -17,14 +17,14 @@ set -u
 
 
 # Set colors for echo
-black='\E[30;40m'
-red='\E[1;31;40m'
-green='\E[32;40m'
-yellow='\E[33;40m'
-blue='\E[1;34;40m'
-magenta='\E[35;40m'
-cyan='\E[36;40m'
-white='\E[1;37;40m'
+black='\E[30;49m'
+red='\E[1;31;49m'
+green='\E[32;49m'
+yellow='\E[33;49m'
+blue='\E[1;34;49m'
+magenta='\E[35;49m'
+cyan='\E[36;49m'
+white='\E[1;37;49m'
 reset=$(tput sgr0)
 
 # Default variables

--- a/atop
+++ b/atop
@@ -26,7 +26,7 @@ reset=$(tput sgr0)
 
 # Default variables
 limit='-n 300'
-STATUS_URL="http://localhost/server-status"
+STATUS_URL="http://127.0.0.1/server-status"
 
 # Parse arguments
 while [[ $@ > 0 ]]; do
@@ -42,7 +42,7 @@ while [[ $@ > 0 ]]; do
       "-h" | "--help")
         echo -e "-h help\n"
         echo -e "-n\n  Limit number of lines returned (default: 300)\n"
-        echo -e "-u\n  Specify apache status URL (default: http://localhost/server-status)\n"
+        echo -e "-u\n  Specify apache status URL (default: http://127.0.0.1/server-status)\n"
         exit
       ;;
     esac
@@ -78,7 +78,7 @@ do
             while [[ -z "$looper" ]]
             do
                 tput clear
-                links -dump http://localhost/server-status | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}' | head $limit
+                links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}' | head $limit
                 #service httpd fullstatus | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}'
                 show_key
                 read -s -n 1 -t 1 looper || true
@@ -92,7 +92,7 @@ do
             while [[ -z "$looper" ]]
             do
                 tput clear
-                links -dump http://localhost/server-status | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[GCRK.]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
+                links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[GCRK.]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
                 show_key
                 read -s -n 1 -t 1 looper || true
             done
@@ -102,7 +102,7 @@ do
 
         d)  # sort by Domain
             echo "# sort by Domain"
-            #links -dump http://localhost/server-status | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $13 !~ /OPTIONS/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 7 -n"}'
+            #links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $13 !~ /OPTIONS/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 7 -n"}'
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
         ;;
@@ -114,9 +114,9 @@ do
             do
                 iplist=''
                 tput clear
-                echo "List of IPs connected to port 80 (using Apache Server Status)"
+                echo "List of IPs connected (using Apache Server Status)"
                 echo
-                links -dump http://localhost/server-status | grep ^[0-9] | grep -v "129.174" | grep -v "server-status" | awk '{print $4, $11}' | grep -v "\?" | grep -v "^\." | awk '{print $2}' | sort -n | uniq -c | sort -n
+                links -dump $STATUS_URL | grep ^[0-9] | grep -v "129.174" | grep -v "server-status" | awk '{print $4, $11}' | grep -v "\?" | grep -v "^\." | awk '{print $2}' | sort -n | uniq -c | sort -n
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
                 read -s -n 1 -t 1 looper || true
@@ -134,7 +134,7 @@ might be keeping old connections alive too long.  You may want
 to look into reducing the amount of time connections are kept
 alive by apache via the KeepAliveTimeout directive"
                 echo
-                links -dump http://localhost/server-status | grep ^[0-9] | grep -v "server-status" | grep "K" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
+                links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | grep "K" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
                 read -s -n 1 -t 1 looper || true
@@ -177,7 +177,7 @@ alive by apache via the KeepAliveTimeout directive"
             while [[ -z "$looper" ]]
             do
                 tput clear
-                links -dump http://localhost/server-status | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[_KGSDIRCWL]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
+                links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[_KGSDIRCWL]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
                 show_key
                 read -s -n 1 -t 1 looper || true
             done
@@ -189,7 +189,7 @@ alive by apache via the KeepAliveTimeout directive"
             while [[ -z "$looper" ]]
             do
                 tput clear
-                links -dump http://localhost/server-status | grep ^[0-9] | grep -v "server-status" | grep "POST" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[.]/ {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}' | head $limit
+                links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | grep "POST" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[.]/ {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}' | head $limit
                 #service httpd fullstatus | grep ^[0-9] | grep -v "server-status" | grep "POST" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}'
                 echo
                 show_key
@@ -203,7 +203,7 @@ alive by apache via the KeepAliveTimeout directive"
             while [[ -z "$looper" ]]
             do
                 tput clear
-                links -dump http://localhost/server-status | head $limit
+                links -dump $STATUS_URL | head $limit
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
                 read -s -n 1 -t 1 looper || true
@@ -221,7 +221,7 @@ alive by apache via the KeepAliveTimeout directive"
                 fi
                 echo -e "Returning results with $magenta $word $reset"
                 echo
-                links -dump http://localhost/server-status | grep $word || true
+                links -dump $STATUS_URL | grep $word || true
                 echo
                 show_key
                 read -s -n 1 -t 1 looper || true
@@ -236,7 +236,7 @@ alive by apache via the KeepAliveTimeout directive"
             while [[ -z "$looper" ]]
             do
                 tput clear
-                links -dump http://localhost/server-status | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[WGCRK_]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
+                links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[WGCRK_]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
                 read -s -n 1 -t 1 looper || true
@@ -256,7 +256,7 @@ alive by apache via the KeepAliveTimeout directive"
             while [[ -z "$looper" ]]
             do
                 tput clear
-                links -dump http://localhost/server-status | grep ^[0-9] | grep -v "server-status" | grep "POST" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[.]/ {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}' | head $limit
+                links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | grep "POST" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[.]/ {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}' | head $limit
                 echo
                 show_key
                 read -s -n 1 -t 1 looper || true
@@ -272,7 +272,7 @@ alive by apache via the KeepAliveTimeout directive"
     echo "=================================================="
     echo "    a = sort all threads by time
     c = sort by CPU, no 'GCRK.'
-    i = list IPs connected to port 80 (uses Apache Server Status)
+    i = list IPs connected (uses Apache Server Status)
     k = sort by K (Keep alives)
     l = list IPs connected to all ports (using netstat)
     n = list IPs connected to port 80 (uses netstat)

--- a/atop
+++ b/atop
@@ -1,4 +1,13 @@
 #!/bin/bash
+# atop
+#
+# Forked from chnm's atop.
+# https://github.com/chnm/atop
+#
+# Updated to support arguments and
+# non default status URL.
+# <ricky@rickyhewitt.com>
+#
 
 set -e
 set -u
@@ -15,23 +24,38 @@ cyan='\E[36;40m'
 white='\E[1;37;40m'
 reset=$(tput sgr0)
 
+# Default variables
+limit='-n 300'
+STATUS_URL="http://localhost/server-status"
 
+# Parse arguments
+while [[ $@ > 0 ]]; do
+    case "$1" in
+      "-n" | "--number")
+          limit="-n $2"
+      ;;
 
-if [[ -n "${1-}" ]]; then
+      "-u" | "--url")
+          STATUS_URL="$2"
+      ;;
 
-    limit="-n $1"
-else
-    limit='-n 300'
-fi
-
+      "-h" | "--help")
+        echo -e "-h help\n"
+        echo -e "-n\n  Limit number of lines returned (default: 300)\n"
+        echo -e "-u\n  Specify apache status URL (default: http://localhost/server-status)\n"
+        exit
+      ;;
+    esac
+    shift
+done
 
 function show_key
 {
-            echo 
-            echo -e " $yellow State Column Key: 
-            _ Waiting for Connection    S Starting up    R Reading Request    W Sending Reply 
-            K Keepalive (read)          D DNS Lookup     C Closing connection L Logging 
-            G Gracefully finishing      I Idle cleanup of worker   
+            echo
+            echo -e " $yellow State Column Key:
+            _ Waiting for Connection    S Starting up    R Reading Request    W Sending Reply
+            K Keepalive (read)          D DNS Lookup     C Closing connection L Logging
+            G Gracefully finishing      I Idle cleanup of worker
             . Open slot with no current process $reset "
 
             echo
@@ -44,7 +68,7 @@ function show_key
 choose=''
 
 
-# to limit the types of connections returned, put the follwing between the print and printf commands. $4 !~ /[GCRK_.]/ 
+# to limit the types of connections returned, put the follwing between the print and printf commands. $4 !~ /[GCRK_.]/
 while :
 do
 
@@ -99,8 +123,8 @@ do
             done
 
         ;;
-        
-        
+
+
         k)  # sort by KeepAlive, too many means too many old connections kept alive too long
             while [[ -z "$looper" ]]
             do
@@ -185,7 +209,7 @@ alive by apache via the KeepAliveTimeout directive"
                 read -s -n 1 -t 1 looper || true
             done
         ;;
-        
+
 
         s)  # search
             word=''
@@ -203,7 +227,7 @@ alive by apache via the KeepAliveTimeout directive"
                 read -s -n 1 -t 1 looper || true
             done
         ;;
-        
+
 
 
 
@@ -218,7 +242,7 @@ alive by apache via the KeepAliveTimeout directive"
                 read -s -n 1 -t 1 looper || true
             done
         ;;
-        
+
 
 
         q)  # quit

--- a/atop
+++ b/atop
@@ -1,13 +1,16 @@
 #!/bin/bash
+#
 # atop
+# This tool is basically a BASH wrapper script around the "links" command that
+# pulls info from the Apache default mod_status functionality and displays the
+# results on the command line, similar to the "top" command.
 #
-# Forked from chnm's atop.
-# https://github.com/chnm/atop
+# Author: Ammon Shepherd <https://github.com/mossiso>
 #
-# Updated to support arguments and
-# non default status URL.
-# <ricky@rickyhewitt.com>
-#
+# Contrib:
+#   - Roberto Sanchez <https://github.com/rsanc77>
+#   - Ricky Hewitt <https://github.com/rickyhewitt>
+# 
 
 set -e
 set -u

--- a/atop
+++ b/atop
@@ -10,7 +10,7 @@
 # Contrib:
 #   - Roberto Sanchez <https://github.com/rsanc77>
 #   - Ricky Hewitt <https://github.com/rickyhewitt>
-# 
+
 
 set -e
 set -u
@@ -43,9 +43,9 @@ while [[ $@ > 0 ]]; do
       ;;
 
       "-h" | "--help")
-        echo -e "-h help\n"
-        echo -e "-n\n  Limit number of lines returned (default: 300)\n"
-        echo -e "-u\n  Specify apache status URL (default: http://127.0.0.1/server-status)\n"
+        echo -e "-h --help help\n"
+        echo -e "-n --number\n  Limit number of lines returned (default: 300)\n"
+        echo -e "-u --url\n  Specify apache status URL (default: http://127.0.0.1/server-status)\n"
         exit
       ;;
     esac

--- a/atop
+++ b/atop
@@ -253,14 +253,13 @@ alive by apache via the KeepAliveTimeout directive"
 
 
         *)  # default
-            while [[ -z "$looper" ]]
-            do
-                tput clear
-                links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | grep "POST" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[.]/ {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}' | head $limit
-                echo
-                show_key
-                read -s -n 1 -t 1 looper || true
-            done
+          while [[ -z "$looper" ]]
+          do
+              tput clear
+              links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[GCRK.]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
+              show_key
+              read -s -n 1 -t 1 looper || true
+          done
         ;;
     esac
 

--- a/atop
+++ b/atop
@@ -28,12 +28,17 @@ white='\E[1;37;49m'
 reset=$(tput sgr0)
 
 # Default variables
+delay='2'
 limit='-n 300'
 STATUS_URL="http://127.0.0.1/server-status"
 
 # Parse arguments
 while [[ $@ > 0 ]]; do
     case "$1" in
+      "-d" | "--delay")
+          delay="$2"
+      ;;
+
       "-n" | "--number")
           limit="-n $2"
       ;;
@@ -44,6 +49,7 @@ while [[ $@ > 0 ]]; do
 
       "-h" | "--help")
         echo -e "-h --help help\n"
+        echo -e "-d --delay\n  Set the delay between updates, in seconds (default: 2)\n"
         echo -e "-n --number\n  Limit number of lines returned (default: 300)\n"
         echo -e "-u --url\n  Specify apache status URL (default: http://127.0.0.1/server-status)\n"
         exit
@@ -84,7 +90,7 @@ do
                 links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}' | head $limit
                 #service httpd fullstatus | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}'
                 show_key
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -97,7 +103,7 @@ do
                 tput clear
                 links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[GCRK.]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
                 show_key
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -122,7 +128,7 @@ do
                 links -dump $STATUS_URL | grep ^[0-9] | grep -v "129.174" | grep -v "server-status" | awk '{print $4, $11}' | grep -v "\?" | grep -v "^\." | awk '{print $2}' | sort -n | uniq -c | sort -n
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
 
         ;;
@@ -140,7 +146,7 @@ alive by apache via the KeepAliveTimeout directive"
                 links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | grep "K" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -155,7 +161,7 @@ alive by apache via the KeepAliveTimeout directive"
                 netstat -tn | awk '{print $5}' | grep -v -e "127.0.0" -e "192.168" -e "129.174" -e "Address" -e "servers" | cut -d: -f1 | sort | uniq -c | sort -n
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -170,7 +176,7 @@ alive by apache via the KeepAliveTimeout directive"
                 netstat -tn | grep ":443" | awk '{print $5}' | grep -v -e "127.0.0" -e "129.174" | cut -d: -f1 | sort | uniq -c | sort -n
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -185,7 +191,7 @@ alive by apache via the KeepAliveTimeout directive"
                 netstat -tn | grep ":80" | awk '{print $5}' | grep -v -e "127.0.0" -e "129.174" | cut -d: -f1 | sort | uniq -c | sort -n
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -197,7 +203,7 @@ alive by apache via the KeepAliveTimeout directive"
                 tput clear
                 links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[_KGSDIRCWL]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
                 show_key
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -211,7 +217,7 @@ alive by apache via the KeepAliveTimeout directive"
                 #service httpd fullstatus | grep ^[0-9] | grep -v "server-status" | grep "POST" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} {printf "%-6s %6s %6s %-4s %-10s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -n"}'
                 echo
                 show_key
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -224,7 +230,7 @@ alive by apache via the KeepAliveTimeout directive"
                 links -dump $STATUS_URL | head $limit
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -242,7 +248,7 @@ alive by apache via the KeepAliveTimeout directive"
                 links -dump $STATUS_URL | grep $word || true
                 echo
                 show_key
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -257,7 +263,7 @@ alive by apache via the KeepAliveTimeout directive"
                 links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[WGCRK_]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
                 echo
                 echo -e "$green Type any key to switch sort options. $reset"
-                read -s -n 1 -t 1 looper || true
+                read -s -n 1 -t $delay looper || true
             done
         ;;
 
@@ -276,7 +282,7 @@ alive by apache via the KeepAliveTimeout directive"
               tput clear
               links -dump $STATUS_URL | grep ^[0-9] | grep -v "server-status" | awk 'BEGIN {print "Seconds  PID    CPU State TYPE         IP                  Domain/URL\n--"} $4 !~ /[GCRK.]/ {printf "%-6s %6s %6s %-4s %-8s %-20s %2s %-2s\n",  $6, $2, $5,"  " $4, $13, $11, $12, $14|"sort -k 3 -n"}' | head $limit
               show_key
-              read -s -n 1 -t 1 looper || true
+              read -s -n 1 -t $delay looper || true
           done
         ;;
     esac

--- a/atop
+++ b/atop
@@ -161,6 +161,21 @@ alive by apache via the KeepAliveTimeout directive"
 
 
 
+        m) # Netstat list of IPs
+            while [[ -z "$looper" ]]
+            do
+                tput clear
+                echo "List of IPs connected to port 443 (using netstat)"
+                echo
+                netstat -tn | grep ":443" | awk '{print $5}' | grep -v -e "127.0.0" -e "129.174" | cut -d: -f1 | sort | uniq -c | sort -n
+                echo
+                echo -e "$green Type any key to switch sort options. $reset"
+                read -s -n 1 -t 1 looper || true
+            done
+        ;;
+
+
+
         n) # Netstat list of IPs
             while [[ -z "$looper" ]]
             do
@@ -277,6 +292,7 @@ alive by apache via the KeepAliveTimeout directive"
     i = list IPs connected (uses Apache Server Status)
     k = sort by K (Keep alives)
     l = list IPs connected to all ports (using netstat)
+    m = list IPs connected to port 443 (uses netstat)
     n = list IPs connected to port 80 (uses netstat)
     o = sort open connections by CPU
     p = sort only POST threads by time


### PR DESCRIPTION
- -h / --help option has been added
- -n / --number has been added for optional max lines
- -u / --url has been added for an optional custom server-status URL
- Default behaviour has been changed from POST to CPU (apache status)
- Additional documentation.
